### PR TITLE
Stop changing directory when sourcing files

### DIFF
--- a/load.Rmd
+++ b/load.Rmd
@@ -680,8 +680,9 @@ file.copy("load.Rmd", file.path(pct_data, region, "load.Rmd"))
 region_dir <- file.path(file.path(pct_shiny_regions, region))
 dir.create(region_dir)
 ui_text <- 'source("../../ui-base.R", local = T, chdir = T)'
-server_text <- paste0('startingCity <- "', region, '"', "\n",
-                      'source("../../server-base.R", local = T, chdir = T)')
+server_text <- paste0('startingCity <- "', region, '"\n',
+                      'shinyRoot <- file.path("..", "..")\n',
+                      'source(file.path(shinyRoot, "server-base.R"), local = T)')
 write(ui_text, file = file.path(region_dir, "ui.R"))
 write(server_text, file = file.path(region_dir, "server.R"))
 file.symlink(file.path("..", "..","www"), region_dir)


### PR DESCRIPTION
Anything inside shinyServer runs with working
directory equal to the server.R path, e.g.

/pct-shiny/regions_www/leeds/server.R

``` R
setwd('/newdir')
getwd() # /newdir
shinyServer(function(input, output, session){
getwd() # /pct-shiny/regions_www/leeds
})
```
